### PR TITLE
feat: infinite products list

### DIFF
--- a/apps/server/src/routers/index.ts
+++ b/apps/server/src/routers/index.ts
@@ -1,4 +1,3 @@
-import { gt } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { productStats, products } from "../db/schema/products";
@@ -8,14 +7,23 @@ export const appRouter = router({
 	healthCheck: publicProcedure.query(() => {
 		return "OK";
 	}),
-	getAllProducts: publicProcedure.query(async () => {
-		const allProducts = await db.select().from(products).limit(50).offset(0);
-		await new Promise((resolve) => setTimeout(resolve, 3000));
+       getAllProducts: publicProcedure
+               .input(
+                       z.object({
+                               limit: z.number().optional(),
+                               offset: z.number().optional(),
+                       }),
+               )
+               .query(async ({ input }) => {
+                       const allProducts = await db
+                               .select()
+                               .from(products)
+                               .orderBy(products.id)
+                               .limit(input.limit ?? 20)
+                               .offset(input.offset ?? 0);
 
-		return {
-			products: allProducts,
-		};
-	}),
+                       return allProducts;
+               }),
 	getLatestProductStats: publicProcedure.query(async () => {
 		const latestStats = await db
 			.select()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,9 +25,10 @@
 		"zod": "^3.25.16",
 		"@trpc/tanstack-react-query": "^11.0.0",
 		"@trpc/client": "^11.0.0",
-		"@trpc/server": "^11.0.0",
-		"@tanstack/react-query": "^5.80.5"
-	},
+                "@trpc/server": "^11.0.0",
+                "@tanstack/react-query": "^5.80.5",
+                "@tanstack/react-virtual": "^3.0.0"
+        },
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4",
 		"@types/node": "^20",

--- a/apps/web/src/app/_components/ProductsTableWrapper.tsx
+++ b/apps/web/src/app/_components/ProductsTableWrapper.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const InfiniteProductsTable = dynamic(
+  () => import("./_components/productsTable").then((m) => m.InfiniteProductsTable),
+  { ssr: false },
+);
+
+export default function ProductsTableWrapper() {
+  return <InfiniteProductsTable />;
+}

--- a/apps/web/src/app/_components/_components/productsTable.tsx
+++ b/apps/web/src/app/_components/_components/productsTable.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { trpc } from "@/lib/trpc/client";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export function InfiniteProductsTable() {
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    data,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = trpc.getAllProducts.useInfiniteQuery(
+    { limit: 50 },
+    {
+      getNextPageParam: (lastPage, pages) => {
+        const offset = pages.flat().length;
+        return lastPage.length ? { limit: 50, offset } : undefined;
+      },
+    },
+  );
+
+  const allProducts = data?.pages.flat() ?? [];
+
+  const virtualizer = useVirtualizer({
+    count: allProducts.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 50,
+    overscan: 10,
+  });
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting) {
+        fetchNextPage().catch(() => {});
+      }
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [fetchNextPage]);
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div ref={parentRef} className="h-[600px] overflow-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>SKU</TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead>Brand</TableHead>
+            <TableHead>Category</TableHead>
+            <TableHead>Subcategory</TableHead>
+            <TableHead>Price</TableHead>
+            <TableHead>Cost</TableHead>
+            <TableHead>Weight</TableHead>
+            <TableHead>Length</TableHead>
+            <TableHead>Width</TableHead>
+            <TableHead>Height</TableHead>
+            <TableHead>Color</TableHead>
+            <TableHead>Size</TableHead>
+            <TableHead>Material</TableHead>
+            <TableHead>Manufacturer</TableHead>
+            <TableHead>Country of Origin</TableHead>
+            <TableHead>Barcode</TableHead>
+            <TableHead>Stock Quantity</TableHead>
+            <TableHead>Min Stock Level</TableHead>
+            <TableHead>Max Stock Level</TableHead>
+            <TableHead>Is Active</TableHead>
+            <TableHead>Is Featured</TableHead>
+            <TableHead>Is Digital</TableHead>
+            <TableHead>Requires Shipping</TableHead>
+            <TableHead>Tax Rate</TableHead>
+            <TableHead>Warranty (Months)</TableHead>
+            <TableHead>Supplier Name</TableHead>
+            <TableHead>Supplier Code</TableHead>
+            <TableHead>Season</TableHead>
+            <TableHead>Collection</TableHead>
+            <TableHead>Style</TableHead>
+            <TableHead>Pattern</TableHead>
+            <TableHead>Fabric Composition</TableHead>
+            <TableHead>Care Instructions</TableHead>
+            <TableHead>Tags</TableHead>
+            <TableHead>Meta Title</TableHead>
+            <TableHead>Meta Description</TableHead>
+            <TableHead>Slug</TableHead>
+            <TableHead>Rating Average</TableHead>
+            <TableHead>Rating Count</TableHead>
+            <TableHead>View Count</TableHead>
+            <TableHead>Purchase Count</TableHead>
+            <TableHead>Created At</TableHead>
+            <TableHead>Updated At</TableHead>
+            <TableHead>Last Restocked At</TableHead>
+            <TableHead>Discontinued At</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+          {virtualItems.map((virtualRow) => {
+            const product = allProducts[virtualRow.index];
+            if (!product) return null;
+            return (
+              <TableRow
+                key={product.id}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  transform: `translateY(${virtualRow.start}px)`,
+                  width: "100%",
+                }}
+              >
+                <TableCell>{product.id}</TableCell>
+                <TableCell className="font-medium">{product.sku}</TableCell>
+                <TableCell className="font-medium">{product.name}</TableCell>
+                <TableCell>{product.description || "N/A"}</TableCell>
+                <TableCell>{product.brand || "N/A"}</TableCell>
+                <TableCell>{product.category || "N/A"}</TableCell>
+                <TableCell>{product.subcategory || "N/A"}</TableCell>
+                <TableCell className="text-right">${product.price || "N/A"}</TableCell>
+                <TableCell className="text-right">${product.cost || "N/A"}</TableCell>
+                <TableCell>{product.weight || "N/A"}</TableCell>
+                <TableCell>{product.length || "N/A"}</TableCell>
+                <TableCell>{product.width || "N/A"}</TableCell>
+                <TableCell>{product.height || "N/A"}</TableCell>
+                <TableCell>{product.color || "N/A"}</TableCell>
+                <TableCell>{product.size || "N/A"}</TableCell>
+                <TableCell>{product.material || "N/A"}</TableCell>
+                <TableCell>{product.manufacturer || "N/A"}</TableCell>
+                <TableCell>{product.country_of_origin || "N/A"}</TableCell>
+                <TableCell>{product.barcode || "N/A"}</TableCell>
+                <TableCell>{product.stock_quantity}</TableCell>
+                <TableCell>{product.min_stock_level}</TableCell>
+                <TableCell>{product.max_stock_level}</TableCell>
+                <TableCell>{product.is_active ? "Yes" : "No"}</TableCell>
+                <TableCell>{product.is_featured ? "Yes" : "No"}</TableCell>
+                <TableCell>{product.is_digital ? "Yes" : "No"}</TableCell>
+                <TableCell>{product.requires_shipping ? "Yes" : "No"}</TableCell>
+                <TableCell>
+                  {product.tax_rate ? `${(product.tax_rate * 100).toFixed(1)}%` : "N/A"}
+                </TableCell>
+                <TableCell>{product.warranty_months || "N/A"}</TableCell>
+                <TableCell>{product.supplier_name || "N/A"}</TableCell>
+                <TableCell>{product.supplier_code || "N/A"}</TableCell>
+                <TableCell>{product.season || "N/A"}</TableCell>
+                <TableCell>{product.collection || "N/A"}</TableCell>
+                <TableCell>{product.style || "N/A"}</TableCell>
+                <TableCell>{product.pattern || "N/A"}</TableCell>
+                <TableCell>{product.fabric_composition || "N/A"}</TableCell>
+                <TableCell>{product.care_instructions || "N/A"}</TableCell>
+                <TableCell>{product.tags || "N/A"}</TableCell>
+                <TableCell>{product.meta_title || "N/A"}</TableCell>
+                <TableCell>{product.meta_description || "N/A"}</TableCell>
+                <TableCell>{product.slug || "N/A"}</TableCell>
+                <TableCell>
+                  {product.rating_average ? product.rating_average.toFixed(1) : "N/A"}
+                </TableCell>
+                <TableCell>{product.rating_count}</TableCell>
+                <TableCell>{product.view_count}</TableCell>
+                <TableCell>{product.purchase_count}</TableCell>
+                <TableCell>
+                  {product.created_at?.toLocaleDateString() || "N/A"}
+                </TableCell>
+                <TableCell>
+                  {product.updated_at?.toLocaleDateString() || "N/A"}
+                </TableCell>
+                <TableCell>
+                  {product.last_restocked_at?.toLocaleDateString() || "N/A"}
+                </TableCell>
+                <TableCell>
+                  {product.discontinued_at?.toLocaleDateString() || "N/A"}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      <div ref={sentinelRef} className="h-4" />
+      {isFetchingNextPage && <div className="p-4 text-center">Loading...</div>}
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,17 +1,20 @@
+import { Suspense } from "react";
 import { ProductStats } from "@/app/_components/stat";
+import ProductsTableWrapper from "./_components/ProductsTableWrapper";
+import { Skeleton } from "@/components/ui/skeleton";
 import { caller } from "@/lib/trpc/server";
-import { ProductsTable } from "./_components/table";
 
 export default async function Home() {
-	const { stats } = await caller.getLatestProductStats();
-	const { products } = await caller.getAllProducts();
+       const { stats } = await caller.getLatestProductStats();
 
-	return (
-		<div className="container mx-auto px-4 py-8">
-			<div className="grid gap-6">
-				<ProductStats stats={stats} />
-				<ProductsTable products={products} />
-			</div>
-		</div>
-	);
+       return (
+               <div className="container mx-auto px-4 py-8">
+                       <div className="grid gap-6">
+                               <ProductStats stats={stats} />
+                               <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+                                       <ProductsTableWrapper />
+                               </Suspense>
+                       </div>
+               </div>
+       );
 }


### PR DESCRIPTION
## Summary
- paginate `getAllProducts` procedure
- wrap table in Suspense and use Skeleton fallback
- add client wrapper for products table
- implement infinite loading table with IntersectionObserver
- virtualize rows with `@tanstack/react-virtual`

## Testing
- `bun run check-types` *(fails: turbo not found)*
- `bun run check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e122e922c832da590a4aef15455af