### PR TITLE
Fix type errors in infinite query

### DIFF
--- a/apps/web/src/app/_components/_components/productsTable.tsx
+++ b/apps/web/src/app/_components/_components/productsTable.tsx
@@ -2,7 +2,8 @@
 
 import { useRef, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { trpc } from "@/lib/trpc/client";
+import { useTRPC } from "@/lib/trpc/client";
+import type { Product } from "@server/db/schema/products";
 import {
   Table,
   TableBody,
@@ -16,6 +17,8 @@ export function InfiniteProductsTable() {
   const parentRef = useRef<HTMLDivElement | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
+  const trpc = useTRPC();
+
   const {
     data,
     fetchNextPage,
@@ -23,7 +26,7 @@ export function InfiniteProductsTable() {
   } = trpc.getAllProducts.useInfiniteQuery(
     { limit: 50 },
     {
-      getNextPageParam: (lastPage, pages) => {
+      getNextPageParam: (lastPage: Product[], pages: Product[][]) => {
         const offset = pages.flat().length;
         return lastPage.length ? { limit: 50, offset } : undefined;
       },


### PR DESCRIPTION
## Summary
- annotate `getNextPageParam` parameters
- import `Product` type for inference

## Testing
- `npx biome check apps/web/src/app/_components/_components/productsTable.tsx` *(fails: 403 Forbidden)*
- `bun run check-types` *(fails: command not found: turbo)*
- `bun run check` *(fails: command not found: biome)*

------
https://chatgpt.com/codex/tasks/task_e_685e16714d34832d89ed42d861acd086